### PR TITLE
Various improvements (version discovery via download JSON, CLI, etc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,8 @@ The script requires Python 3.5 or later.
 Install the dependencies:
 
 ```shell
-pip install wheel twine libarchive-c
+pip install wheel twine
 ```
-
-The `libarchive-c` Python library requires the native [libarchive][] library to be available.
-
-[libarchive]: https://libarchive.org/
 
 Building wheels
 ---------------

--- a/make_wheels.py
+++ b/make_wheels.py
@@ -1,11 +1,26 @@
-import os
+import argparse
 import hashlib
+import io
+import json
+import os
+import tarfile
 import urllib.request
 from email.message import EmailMessage
-from wheel.wheelfile import WheelFile, get_zipinfo_datetime
-from zipfile import ZipInfo, ZIP_DEFLATED
-import libarchive # from libarchive-c
+from zipfile import ZIP_DEFLATED, ZipFile, ZipInfo
 
+from wheel.wheelfile import WheelFile
+
+ZIG_VERSION_INFO_URL = 'https://ziglang.org/download/index.json'
+ZIG_PYTHON_PLATFORMS = {
+    'x86_64-windows': 'win_amd64',
+    'x86_64-macos':   'macosx_10_9_x86_64',
+    'aarch64-macos':  'macosx_11_0_arm64',
+    'i386-linux':     'manylinux_2_12_i686.manylinux2010_i686.musllinux_1_1_i686',
+    'x86_64-linux':   'manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64',
+    'aarch64-linux':  'manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64',
+    # no longer present?
+    # 'armv7a-linux':   'manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l',
+}
 
 class ReproducibleWheelFile(WheelFile):
     def writestr(self, zinfo, *args, **kwargs):
@@ -61,28 +76,65 @@ def write_wheel(out_dir, *, name, version, tag, metadata, description, contents)
     })
 
 
-def write_ziglang_wheel(out_dir, *, version, platform, archive):
+def iter_archive_contents(archive):
+    magic = archive[:4]
+    if magic[:4] == b"\xfd7zX":
+        with tarfile.open(mode="r|xz", fileobj=io.BytesIO(archive)) as tar:
+            for entry in tar:
+                if entry.isreg():
+                    yield entry.name, entry.mode | (1 << 15), tar.extractfile(entry).read()
+    elif magic[:4] == b"PK\x03\x04":
+        with ZipFile(io.BytesIO(archive)) as zip_file:
+            for entry in zip_file.infolist():
+                yield entry.filename, entry.external_attr >> 16, zip_file.read(entry)
+    else:
+        raise RuntimeError("Unsupported archive format")
+
+def write_ziglang_wheel(out_dir, *, version, zig_version, platform, archive):
     contents = {}
-    contents['ziglang/__init__.py'] = b''
 
-    with libarchive.memory_reader(archive) as archive:
-        for entry in archive:
-            entry_name = '/'.join(entry.name.split('/')[1:])
-            if entry.isdir or not entry_name:
-                continue
+    contents['ziglang/__main__.py'] = b'''\
+import sys
 
-            zip_info = ZipInfo(f'ziglang/{entry_name}')
-            zip_info.external_attr = (entry.mode & 0xFFFF) << 16
-            contents[zip_info] = b''.join(entry.get_blocks())
+from . import main
 
-            if entry_name.startswith('zig'):
-                contents['ziglang/__main__.py'] = f'''\
-import os, sys, subprocess
-sys.exit(subprocess.call([
-    os.path.join(os.path.dirname(__file__), "{entry_name}"),
-    *sys.argv[1:]
-]))
+if __name__ == "__main__":
+    sys.exit(main())
+'''
+
+    for entry_name, entry_mode, entry_data in iter_archive_contents(archive):
+        entry_name = '/'.join(entry_name.split('/')[1:])
+        if not entry_name:
+            continue
+
+        zip_info = ZipInfo(f'ziglang/{entry_name}')
+        zip_info.external_attr = (entry_mode & 0xFFFF) << 16
+        contents[zip_info] = entry_data
+
+        if entry_name.startswith('zig'):
+            contents['ziglang/__init__.py'] = f'''\
+import os
+import subprocess
+import sys
+
+__version__ = "{version}"
+__zig_version__ = "{zig_version}"
+__zig_local_path__ = "{entry_name}"
+__zig_path__ = os.path.join(os.path.dirname(__file__), __zig_local_path__)
+
+__all__ = ["zig"]
+
+
+def zig(*args, **kwargs):
+    return subprocess.call([__zig_path__, *args], **kwargs)
+
+
+def main(argv=None):
+    if argv is None:
+        argv = sys.argv[1:]
+    return zig(*argv)
 '''.encode('ascii')
+
 
     with open('README.pypi.md') as f:
         description = f.read()
@@ -110,33 +162,57 @@ sys.exit(subprocess.call([
     )
 
 
-zig_version = '0.10.1'
+def fetch_zig_version_info():
+    with urllib.request.urlopen(ZIG_VERSION_INFO_URL) as request:
+        return json.loads(request.read())
 
-python_version_suffix = ''
-if zig_version == '0.10.1':
-    # When updating zig_version above, reset python_version_suffix to ''.
-    # When uploading a new Python wheel that packages the same Zig binaries,
-    # set python_version_suffix to '.post1', '.post2', ... as necessary.
-    python_version_suffix = '.post1'
 
-for zig_platform, python_platform in {
-    'windows-x86_64': 'win_amd64',
-    'macos-x86_64':   'macosx_10_9_x86_64',
-    'macos-aarch64':  'macosx_11_0_arm64',
-    'linux-i386':     'manylinux_2_12_i686.manylinux2010_i686.musllinux_1_1_i686',
-    'linux-x86_64':   'manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64',
-    'linux-armv7a':   'manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l',
-    'linux-aarch64':  'manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64',
-}.items():
-    zig_url = f'https://ziglang.org/download/{zig_version}/zig-{zig_platform}-{zig_version}.' + \
-              ('zip' if zig_platform.startswith('windows-') else 'tar.xz')
-    with urllib.request.urlopen(zig_url) as request:
-        zig_archive = request.read()
-        print(f'{hashlib.sha256(zig_archive).hexdigest()} {zig_url}')
+def fetch_and_write_ziglang_wheels(outdir='dist/', zig_version='master', python_version_suffix='', platforms=tuple()):
+    if not platforms:
+        platforms = list(ZIG_PYTHON_PLATFORMS)
+    zig_versions_info = fetch_zig_version_info()
 
-    wheel_path = write_ziglang_wheel('dist/',
-        version=zig_version + python_version_suffix,
-        platform=python_platform,
-        archive=zig_archive)
-    with open(wheel_path, 'rb') as wheel:
-        print(f'  {hashlib.sha256(wheel.read()).hexdigest()} {wheel_path}')
+    try:
+        zig_version_info = zig_versions_info[zig_version]
+    except KeyError:
+        print(f"Invalid version, valid values: {list(zig_versions_info.keys())}")
+        raise
+
+    effective_zig_version = zig_version_info.get('version', zig_version)
+
+    for zig_platform in platforms:
+        python_platform = ZIG_PYTHON_PLATFORMS[zig_platform]
+        zig_download = zig_version_info[zig_platform]
+        zig_url = zig_download['tarball']
+        expected_hash = zig_download['shasum']
+        with urllib.request.urlopen(zig_url) as request:
+            zig_archive = request.read()
+            zig_archive_hash = hashlib.sha256(zig_archive).hexdigest()
+            if zig_archive_hash != expected_hash:
+                print(zig_download, "SHA256 hash mismatch!")
+                raise AssertionError
+
+            print(f'{zig_archive_hash} {zig_url}')
+
+        wheel_path = write_ziglang_wheel(outdir,
+            version=effective_zig_version.replace('-', '.') + python_version_suffix,
+            zig_version=effective_zig_version,
+            platform=python_platform,
+            archive=zig_archive)
+        with open(wheel_path, 'rb') as wheel:
+            print(f'  {hashlib.sha256(wheel.read()).hexdigest()} {wheel_path}')
+
+def get_argparser():
+    parser = argparse.ArgumentParser(prog=__file__, description="Repackage official Zig downloads as Python wheels")
+    parser.add_argument("--version", default="0.10.1")
+    parser.add_argument("--suffix", default=".post2")
+    parser.add_argument("--outdir", default="dist/")
+    parser.add_argument("--platform", action="append", choices=list(ZIG_PYTHON_PLATFORMS.keys()), default=[])
+    return parser
+
+def main():
+    args = get_argparser().parse_args()
+    fetch_and_write_ziglang_wheels(zig_version=args.version, python_version_suffix=args.suffix, platforms=args.platform)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Thanks for having zig on PyPI, this makes installing it quite easy!
This packaging tool is quite useful, here a PR to possibly add some more features:

- Use [download JSON](https://ziglang.org/download/index.json) to discover versions
- Allow packaging of current main version (c.f. `python make_wheels.py --version master --suffix ""`)
- Add CLI interface for make_wheels.py
- Add version info (`ziglang.__version__`) and an additional entrypoint (`ziglang.zig("arg1", "arg2")`) to package

Furthermore, the `libarchive` dependency is removed.
In general, I would not hardcode the `--version` and `--suffix` parameters as they are now to match the behavior of the old script.
Using Github Actions, the packaging could be automated further.