### PR TITLE
Add a argparse to accept command line parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,22 @@ Building wheels
 Run the repackaging script:
 
 ```shell
-python make_wheels.py
+python make_wheels.py --help
+usage: make_wheels.py [-h] [--version VERSION] [--suffix SUFFIX] [--outdir OUTDIR]
+                                                  [--platform {x86_64-windows,x86_64-macos,aarch64-macos,i386-linux,x86-linux,x86_64-linux,aarch64-linux,armv7a-linux}]
+
+Repackage official Zig downloads as Python wheels
+
+options:
+  -h, --help            show this help message and exit
+  --version VERSION     version to package, use `latest` for latest release, `master` for nightly build
+  --suffix SUFFIX       wheel version suffix
+  --outdir OUTDIR       target directory
+  --platform {x86_64-windows,x86_64-macos,aarch64-macos,i386-linux,x86-linux,x86_64-linux,aarch64-linux,armv7a-linux}
+                        platform to build for, can be repeated
 ```
 
-This command will download the Zig release archives for every supported platform and convert them to binary wheels, which are placed under `dist/`. The Zig version and platforms are configured in the script source.
+This command will download the Zig release archives for every supported platform and convert them to binary wheels, which are placed under `dist/`. The Zig version and platforms can be passed as arguments.
 
 The process of converting release archives to binary wheels is deterministic, and the output of the script should be bit-for-bit identical regardless of the environment and platform it runs under. To this end, it prints the SHA256 hashes of inputs and outputs; the hashes of the inputs will match the ones on the [Zig downloads page][zigdl], and the hashes of the outputs will match the ones on the [PyPI downloads page][pypidl].
 


### PR DESCRIPTION
Thanks for merging #11. Here another split off from #10 .  (Plus additionally allowing `latest` as an version argument now).
Allows to pass arguments via command line. Certainly no necessity, but might be nice.
