### PR TITLE
allow newer wheel dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0"
 
 requires-python = "~=3.7"
 dependencies = [
-  "wheel~=0.38.0",
+  "wheel~=0.41.0",
 ]
 
 [tool.pdm.dev-dependencies]


### PR DESCRIPTION
The error mentioned in #13 is due to the changes introduced by https://github.com/pypa/wheel/pull/511 which changed the `RECORD` file creation from creating a `ZipInfo` in `ẀheelFile.close()` to just using `WheelFile.writestr(<name>, <contents>)`, which led to the error in the overridden method in `ReproducibleWheelFile`.

This PR allows usage of newer `wheel`.

However, in general, it seems the standard for files in wheels is 664 (rw-rw-r--) not 644 (rw-r--r--), furthermore the PR mentioned above was specifically added to set the `S_IFREG` bit, which the current code does not set.

To address this in the future, I'd propose for a version jump at which changes in the produced wheels are okay to just use `wheel`'s `writestr()` along setting env var `SOURCE_DATE_EPOCH` which `wheel` will respect and use for all otherwise unset times, yielding reproducible wheels.
An idea how to switch to that would be in https://github.com/csachs/zig-pypi/tree/simplerWheel (this would yield binary different wheels tho).