### PR TITLE
Don't include doc/ in the wheel.

### DIFF
--- a/make_wheels.py
+++ b/make_wheels.py
@@ -107,6 +107,8 @@ def write_ziglang_wheel(out_dir, *, version, platform, archive):
         entry_name = '/'.join(entry_name.split('/')[1:])
         if not entry_name:
             continue
+        if entry_name.startswith('doc/'):
+            continue
 
         zip_info = ZipInfo(f'ziglang/{entry_name}')
         zip_info.external_attr = (entry_mode & 0xFFFF) << 16


### PR DESCRIPTION
Fixes #14.  Reduces .whl size by ~6MB (-7%), and extracted size by ~45MB (-12%).

/cc @gatesn