### PR TITLE
Build 32-bit Windows wheels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ __pycache__/
 /.pdm-python
 /.venv
 /pdm.lock
+
+# Don't push any wheels
+*.whl

--- a/make_wheels.py
+++ b/make_wheels.py
@@ -13,6 +13,7 @@ from zipfile import ZipFile, ZipInfo, ZIP_DEFLATED
 ZIG_VERSION_INFO_URL = 'https://ziglang.org/download/index.json'
 ZIG_PYTHON_PLATFORMS = {
     'x86_64-windows': 'win_amd64',
+    'x86-windows':   'win32',
     'x86_64-macos':   'macosx_10_9_x86_64',
     'aarch64-macos':  'macosx_11_0_arm64',
     'i386-linux':     'manylinux_2_12_i686.manylinux2010_i686.musllinux_1_1_i686',

--- a/make_wheels.py
+++ b/make_wheels.py
@@ -17,12 +17,11 @@ ZIG_PYTHON_PLATFORMS = {
     'x86_64-macos':   'macosx_10_9_x86_64',
     'aarch64-macos':  'macosx_11_0_arm64',
     'i386-linux':     'manylinux_2_12_i686.manylinux2010_i686.musllinux_1_1_i686',
-    # renamed i386 to x86
+    # renamed i386 to x86 since v0.11.0, i386 was last supported in v0.10.1
     'x86-linux':      'manylinux_2_12_i686.manylinux2010_i686.musllinux_1_1_i686',
     'x86_64-linux':   'manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64',
     'aarch64-linux':
         'manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64',
-    # no longer present?
     'armv7a-linux':   'manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l',
 }
 


### PR DESCRIPTION
## Description

Closes #18

1. Added `x86-windows` and the corresponding wheel tag to the dictionary
2. Added `.whl` files to the `.gitignore` directory so that they are never pushed to the source
3. Clarified some past comments about the availability of wheels on 32-bit Linux and ARMv7 Linux platforms.

## Additional context

N/A
