### PR TITLE
Bump minimum required Mac OS X version to `12.0`

### DIFF
--- a/make_wheels.py
+++ b/make_wheels.py
@@ -15,8 +15,8 @@ ZIG_VERSION_INFO_URL = 'https://ziglang.org/download/index.json'
 ZIG_PYTHON_PLATFORMS = {
     'x86_64-windows': 'win_amd64',
     'x86-windows':    'win32',
-    'x86_64-macos':   'macosx_11_7_x86_64',
-    'aarch64-macos':  'macosx_11_7_arm64',
+    'x86_64-macos':   'macosx_12_0_x86_64',
+    'aarch64-macos':  'macosx_12_0_arm64',
     'i386-linux':     'manylinux_2_12_i686.manylinux2010_i686.musllinux_1_1_i686',
     # renamed i386 to x86 since v0.11.0, i386 was last supported in v0.10.1
     'x86-linux':      'manylinux_2_12_i686.manylinux2010_i686.musllinux_1_1_i686',


### PR DESCRIPTION
Based on discussion in the commit 266bbddd614bf7a8f3691ae58148c8f6b0625136. `11.7` isn't a supported Mac OS X version due to `pip` limitations since it's not able to detect the minor Mac OS X version. In this case, it's better to bump to a minimum Mac OS X version of 12.0 (Monterey) so that people don't get to install `ziglang` at all from PyPI on Mac OS X 11.Y (Big Sur) where Y<7. Apologies for the previous mishap which repaired the wheel to have an un-installable `11_7` tag (this is fixed in both `delocate` and `repairwheel` now, I think).