### PR TITLE
Remove extra attributes from "Description-Content-Type"

### DIFF
--- a/make_wheels.py
+++ b/make_wheels.py
@@ -225,7 +225,7 @@ else:
         tag=f'py3-none-{platform}',
         metadata=[
             ('Summary', 'Zig is a general-purpose programming language and toolchain for maintaining robust, optimal, and reusable software.'),
-            ('Description-Content-Type', "'text/markdown'; charset=UTF-8; variant=GFM"),
+            ('Description-Content-Type', 'text/markdown'),
             # The license expression and the file paths MUST remain in sync
             # with the paths in the official Zig tarballs and with the ones
             # defined above in the contents. The difference is that these


### PR DESCRIPTION
## Description

This should fix the error on uploading to PyPI (strange that this isn't working, though).

## Additional context

Please see https://github.com/ziglang/zig-pypi/pull/26#issuecomment-2479273993