### PR TITLE
Add `win_arm64` wheels

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Preparation
 
 The script requires Python 3.9 and later and a [PEP 723][pep723] compatible script
 runner, such as [`pipx`][pipx], [`pdm`][pdm], [`hatch`][hatch], [`uv`][uv], or
-similar. Please refer to their ocumentation for installation instructions.
+similar. Please refer to their documentation for installation instructions.
 
 [pep723]: https://peps.python.org/pep-0723/
 [pipx]: https://pipx.pypa.io/stable/examples/#pipx-run-examples

--- a/make_wheels.py
+++ b/make_wheels.py
@@ -25,6 +25,7 @@ from zipfile import ZipFile, ZipInfo, ZIP_DEFLATED
 ZIG_VERSION_INFO_URL = 'https://ziglang.org/download/index.json'
 ZIG_PYTHON_PLATFORMS = {
     'x86_64-windows': 'win_amd64',
+    'aarch64-windows': 'win_arm64',
     'x86-windows':    'win32',
     'x86_64-macos':   'macosx_12_0_x86_64',
     'aarch64-macos':  'macosx_12_0_arm64',


### PR DESCRIPTION
Closes #29; as Windows arm64 runners on GitHub Actions are now in public preview, I think it will also be requested here.