### PR TITLE
Advertise zig and ziglang entry points for `uv`'s sake

### DIFF
--- a/README.pypi.md
+++ b/README.pypi.md
@@ -44,6 +44,8 @@ The Zig compiler distributed in this Python package can be launched by [uv](http
 
 ```shell
 uvx --from ziglang python-zig
+```
+
 License
 -------
 

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -31,15 +31,19 @@ import sys, subprocess
 subprocess.call([sys.executable, "-m", "ziglang"])
 ```
 
-Usage through uv
-----------------
+Binary wrapper
+--------------
 
-Zig-pypi also exposes a Python tool that wraps the zig compiler so that build systems like [uv](https://docs.astral.sh/uv) can easily run the zig compiler:
+The [ziglang][pypi] Python package installs a binary wrapper for the Zig compiler under the name `python-zig`; the name is different to avoid conflicts with any system-wide or user-wide `zig` binaries that may be already installed.
+
+
+Using with `uv`
+---------------
+
+The Zig compiler distributed in this Python package can be launched by [uv](https://docs.astral.sh/uv) without installation:
 
 ```shell
 uvx --from ziglang python-zig
-```
-
 License
 -------
 

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -16,10 +16,10 @@ Although Zig is useful in itself, the Zig toolchain includes a drop-in C and C++
 
 Usage
 -----
-To install and run the Zig toolchain from the command line, use:
+
+To run the Zig toolchain from the command line, use:
 
 ```shell
-pip install ziglang
 python -m ziglang
 ```
 

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -16,10 +16,10 @@ Although Zig is useful in itself, the Zig toolchain includes a drop-in C and C++
 
 Usage
 -----
-
-To run the Zig toolchain from the command line, use:
+To install and run the Zig toolchain from the command line, use:
 
 ```shell
+pip install ziglang
 python -m ziglang
 ```
 
@@ -29,6 +29,15 @@ To run the Zig toolchain from a Python program, use `sys.executable` to locate t
 import sys, subprocess
 
 subprocess.call([sys.executable, "-m", "ziglang"])
+```
+
+Usage through uv
+----------------
+
+Zig-pypi also exposes a Python tool that wraps the zig compiler so that build systems like [uv](https://docs.astral.sh/uv) can easily run the zig compiler:
+
+```shell
+uvx --from ziglang python-zig
 ```
 
 License

--- a/make_wheels.py
+++ b/make_wheels.py
@@ -90,7 +90,7 @@ def write_wheel(out_dir, *, name, version, tag, metadata, description, contents)
     return write_wheel_file(os.path.join(out_dir, wheel_name), {
         **contents,
         f'{dist_info}/entry_points.txt': make_message([],
-            '[console_scripts]\nzig-wrapper-python = ziglang.__main__:main'
+            '[console_scripts]\npython-zig = ziglang.__main__:dummy'
         ),
         f'{dist_info}/METADATA': make_message([
             ('Metadata-Version', '2.4'),
@@ -198,15 +198,14 @@ def write_ziglang_wheel(out_dir, *, version, platform, archive):
 
         if entry_name.startswith('zig'):
             contents['ziglang/__main__.py'] = f'''\
-def main():
-    import os, sys
-    argv = [os.path.join(os.path.dirname(__file__), "{entry_name}"), *sys.argv[1:]]
-    if os.name == 'posix':
-        os.execv(argv[0], argv)
-    else:
-        import subprocess; sys.exit(subprocess.call(argv))
-if __name__ == '__main__':
-    main()
+import os, sys
+argv = [os.path.join(os.path.dirname(__file__), "{entry_name}"), *sys.argv[1:]]
+if os.name == 'posix':
+    os.execv(argv[0], argv)
+else:
+    import subprocess; sys.exit(subprocess.call(argv))
+
+def dummy(): """Dummy function for an entrypoint. Zig is executed as a side effect of the import."""
 '''.encode('ascii')
 
     # 1. Check for missing required licenses paths

--- a/make_wheels.py
+++ b/make_wheels.py
@@ -89,6 +89,9 @@ def write_wheel(out_dir, *, name, version, tag, metadata, description, contents)
 
     return write_wheel_file(os.path.join(out_dir, wheel_name), {
         **contents,
+        f'{dist_info}/entry_points.txt': make_message([],
+            '[console_scripts]\nziglang = ziglang.__main__:main\nzig = ziglang.__main__:main'
+        ),
         f'{dist_info}/METADATA': make_message([
             ('Metadata-Version', '2.4'),
             ('Name', name),
@@ -195,12 +198,15 @@ def write_ziglang_wheel(out_dir, *, version, platform, archive):
 
         if entry_name.startswith('zig'):
             contents['ziglang/__main__.py'] = f'''\
-import os, sys
-argv = [os.path.join(os.path.dirname(__file__), "{entry_name}"), *sys.argv[1:]]
-if os.name == 'posix':
-    os.execv(argv[0], argv)
-else:
-    import subprocess; sys.exit(subprocess.call(argv))
+def main():
+    import os, sys
+    argv = [os.path.join(os.path.dirname(__file__), "{entry_name}"), *sys.argv[1:]]
+    if os.name == 'posix':
+        os.execv(argv[0], argv)
+    else:
+        import subprocess; sys.exit(subprocess.call(argv))
+if __name__ == '__main__':
+    main()
 '''.encode('ascii')
 
     # 1. Check for missing required licenses paths

--- a/make_wheels.py
+++ b/make_wheels.py
@@ -90,7 +90,7 @@ def write_wheel(out_dir, *, name, version, tag, metadata, description, contents)
     return write_wheel_file(os.path.join(out_dir, wheel_name), {
         **contents,
         f'{dist_info}/entry_points.txt': make_message([],
-            '[console_scripts]\nziglang = ziglang.__main__:main\nzig = ziglang.__main__:main'
+            '[console_scripts]\nzig-wrapper-python = ziglang.__main__:main'
         ),
         f'{dist_info}/METADATA': make_message([
             ('Metadata-Version', '2.4'),


### PR DESCRIPTION
This PR advertises `zig` and `ziglang` executables in the `entry_points.txt` portion of the wheel. That means that tools like `uv` (https://docs.astral.sh/uv/guides/tools/#running-tools) can automagically pick them up:

```bash
uvx --refresh --from dist/ziglang-0.14.1-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl python-zig version

Installed 1 package in 667ms
0.14.1
```

When this is published to pypi, uv and pipx users will be able to invoke the zig compiler magically with 

```bash
uvx --from ziglang python-zig
```