### PR TITLE
Make the `--suffix` argument optional in the release workflow, and add a `--platform all` option

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -51,11 +51,12 @@ jobs:
           platforms=${GITHUB_EVENT_INPUTS_PLATFORMS}
           IFS=',' read -r -a platform_array <<< "$platforms"
           for platform in "${platform_array[@]}"; do
-            uv run make_wheels.py \
-            --outdir dist/ \
-            --version ${GITHUB_EVENT_INPUTS_VERSION} \
-            --suffix ${GITHUB_EVENT_INPUTS_SUFFIX} \
-            --platform "$platform"
+            cmd="uv run make_wheels.py --outdir dist/ --version ${GITHUB_EVENT_INPUTS_VERSION}"
+            if [ -n "${GITHUB_EVENT_INPUTS_SUFFIX}" ]; then
+              cmd="$cmd --suffix ${GITHUB_EVENT_INPUTS_SUFFIX}"
+            fi
+            cmd="$cmd --platform $platform"
+            eval "$cmd"
           done
 
       - name: Upload wheel artifacts

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,9 +14,9 @@ on:
         default: ""
       platforms:
         description: >
-          Comma-separated values of platforms to build wheels for
+          Comma-separated list of specific platforms to build wheels for, or use 'all' to build for all supported platforms
         required: false
-        default: "x86_64-windows,aarch64-windows,x86-windows,x86_64-macos,aarch64-macos,i386-linux,x86-linux,x86_64-linux,aarch64-linux,armv7a-linux,arm-linux,powerpc64le-linux,s390x-linux,riscv64-linux"
+        default: "all"
       push_to_pypi:
         description: >
           Whether to push the built wheels to PyPI. Can be 'true' or 'false', defaults to 'false'.
@@ -51,11 +51,10 @@ jobs:
           platforms=${GITHUB_EVENT_INPUTS_PLATFORMS}
           IFS=',' read -r -a platform_array <<< "$platforms"
           for platform in "${platform_array[@]}"; do
-            cmd="uv run make_wheels.py --outdir dist/ --version ${GITHUB_EVENT_INPUTS_VERSION}"
+            cmd="uv run make_wheels.py --outdir dist/ --version ${GITHUB_EVENT_INPUTS_VERSION} --platform $platform"
             if [ -n "${GITHUB_EVENT_INPUTS_SUFFIX}" ]; then
               cmd="$cmd --suffix ${GITHUB_EVENT_INPUTS_SUFFIX}"
             fi
-            cmd="$cmd --platform $platform"
             eval "$cmd"
           done
 

--- a/make_wheels.py
+++ b/make_wheels.py
@@ -338,14 +338,18 @@ def fetch_and_write_ziglang_wheels(
 
 
 def get_argparser():
-    parser = argparse.ArgumentParser(prog=__file__, description="Repackage official Zig downloads as Python wheels")
+    supported_platforms = ', '.join(sorted(ZIG_PYTHON_PLATFORMS.keys()))
+    description = (f"Repackage official Zig downloads as Python wheels.\n\n"
+                   f"Supported platforms: {supported_platforms}")
+    
+    parser = argparse.ArgumentParser(prog=__file__, description=description,
+                                   formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('--version', default='latest',
                         help="version to package, use `latest` for latest release, `master` for nightly build")
     parser.add_argument('--suffix', default='', help="wheel version suffix")
     parser.add_argument('--outdir', default='dist/', help="target directory")
     parser.add_argument('--platform', action='append', default=[],
-                        help=f"platform to build for, use 'all' to build for all supported platforms, can be repeated. "
-                             f"Supported platforms: {', '.join(sorted(ZIG_PYTHON_PLATFORMS.keys()))}")
+                        help="platform to build for, use 'all' to build for all supported platforms, can be repeated")
     return parser
 
 
@@ -357,6 +361,7 @@ def main():
     if 'all' in platforms:
         platforms = list(ZIG_PYTHON_PLATFORMS.keys())
 
+    
     fetch_and_write_ziglang_wheels(outdir=args.outdir, zig_version=args.version,
                                    wheel_version_suffix=args.suffix, platforms=platforms)
 

--- a/make_wheels.py
+++ b/make_wheels.py
@@ -343,16 +343,21 @@ def get_argparser():
                         help="version to package, use `latest` for latest release, `master` for nightly build")
     parser.add_argument('--suffix', default='', help="wheel version suffix")
     parser.add_argument('--outdir', default='dist/', help="target directory")
-    parser.add_argument('--platform', action='append', choices=list(ZIG_PYTHON_PLATFORMS.keys()), default=[],
-                        help="platform to build for, can be repeated")
+    parser.add_argument('--platform', action='append', default=[],
+                        help="platform(s) to build for, can be repeated. Use 'all' to build for all supported platforms.")
     return parser
 
 
 def main():
     args = get_argparser().parse_args()
     logging.getLogger("wheel").setLevel(logging.WARNING)
+
+    platforms = args.platform
+    if 'all' in platforms:
+        platforms = list(ZIG_PYTHON_PLATFORMS.keys())
+
     fetch_and_write_ziglang_wheels(outdir=args.outdir, zig_version=args.version,
-                                   wheel_version_suffix=args.suffix, platforms=args.platform)
+                                   wheel_version_suffix=args.suffix, platforms=platforms)
 
 
 if __name__ == '__main__':

--- a/make_wheels.py
+++ b/make_wheels.py
@@ -345,7 +345,7 @@ def get_argparser():
     parser.add_argument('--outdir', default='dist/', help="target directory")
     parser.add_argument('--platform', action='append', default=[],
                         help=f"platform to build for, use 'all' to build for all supported platforms, can be repeated. "
-                             f"Supported platforms: {', '.join(sorted(ZIG_PYTHON_PLATFORMS.keys())
+                             f"Supported platforms: {', '.join(sorted(ZIG_PYTHON_PLATFORMS.keys()))}")
     return parser
 
 

--- a/make_wheels.py
+++ b/make_wheels.py
@@ -344,7 +344,8 @@ def get_argparser():
     parser.add_argument('--suffix', default='', help="wheel version suffix")
     parser.add_argument('--outdir', default='dist/', help="target directory")
     parser.add_argument('--platform', action='append', default=[],
-                        help="platform(s) to build for, can be repeated. Use 'all' to build for all supported platforms.")
+                        help=f"platform to build for, use 'all' to build for all supported platforms, can be repeated. "
+                             f"Supported platforms: {', '.join(sorted(ZIG_PYTHON_PLATFORMS.keys())
     return parser
 
 


### PR DESCRIPTION
After #22, wheels failed as the `--suffix` argument is always supplied to the wheel generation command when it is optional. This PR fixes it.