### PR TITLE
Support PEP 794 (Metadata-Version: 2.5)

### DIFF
--- a/make_wheels.py
+++ b/make_wheels.py
@@ -108,7 +108,7 @@ def write_wheel(out_dir, *, name, version, tag, metadata, description, contents)
             '[console_scripts]\npython-zig = ziglang.__main__:dummy'
         ),
         f'{dist_info}/METADATA': make_message([
-            ('Metadata-Version', '2.4'),
+            ('Metadata-Version', '2.5'),
             ('Name', name),
             ('Version', version),
             *filtered_metadata,
@@ -281,6 +281,7 @@ def dummy(): """Dummy function for an entrypoint. Zig is executed as a side effe
             ('License-File', 'ziglang/lib/libcxxabi/LICENSE.TXT'),
             ('License-File', 'ziglang/lib/libunwind/LICENSE.TXT'),
             ('License-File', 'ziglang/lib/libc/freebsd/COPYRIGHT'),
+            ('Import-Name', 'ziglang ; private'),
             ('Classifier', 'Development Status :: 4 - Beta'),
             ('Classifier', 'Intended Audience :: Developers'),
             ('Classifier', 'Topic :: Software Development :: Compilers'),


### PR DESCRIPTION
This PR updates the wheel builder to support `Metadata-Version: 2.5` (https://peps.python.org/pep-0794/). The specification is available here: https://packaging.python.org/specifications/core-metadata/. We don't need to add the `Import-Namespace` field since `ziglang` is not a namespace package shared with other projects.

I also added the `private` qualifier from the specification. It doesn't change any conflict-detection behaviour (so tools still prevent another package from claiming `ziglang`). IMO, it just communicates to tools and users that this package doesn't offer a programmatic interface via a public API, and the CLI is the only way to use it. It's also possible to keep `Import-Name` empty instead to indicate this, based on what I interpret from the PEP, but that would require us to to drop `ziglang/__init__.py` and `ziglang/__main__.py`, and that breaks the "use as a module" (`python -m ziglang`) pathway, which we don't want happening.

~> [!IMPORTANT]~
~>  This isn't ready to be merged yet – we need a new release of `pypa/twine`, which itself needs a new `pypa/packaging` release: https://github.com/pypa/packaging/issues/950. PyPI itself needs support to ingest such wheels: https://github.com/pypi/warehouse/issues/19083.~

packaging has made a 26.0 release with support, and support for PyPI was merged in February soon after.