### PR TITLE
Write WHEEL tags in expanded form

### DIFF
--- a/make_wheels.py
+++ b/make_wheels.py
@@ -91,6 +91,17 @@ def write_wheel(out_dir, *, name, version, tag, metadata, description, contents)
     for header, value in metadata:
         filtered_metadata.append((header, value))
 
+    # The WHEEL file must contain the compatibility tags in their expanded form.
+    # see https://packaging.python.org/en/latest/specifications/binary-distribution-format/#file-contents
+    # see https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/#compressed-tag-sets
+    pytag, abitag, platformtag = tag.split("-")
+    expanded_tags = [
+        "-".join((x, y, z))
+        for z in platformtag.split(".")
+        for y in abitag.split(".")
+        for x in pytag.split(".")
+    ]
+
     return write_wheel_file(os.path.join(out_dir, wheel_name), {
         **contents,
         f'{dist_info}/entry_points.txt': make_message([],
@@ -106,7 +117,7 @@ def write_wheel(out_dir, *, name, version, tag, metadata, description, contents)
             ('Wheel-Version', '1.0'),
             ('Generator', 'ziglang make_wheels.py'),
             ('Root-Is-Purelib', 'false'),
-            ('Tag', tag),
+            ('Tag', expanded_tags),
         ]),
     })
 


### PR DESCRIPTION
Hello, pip maintainer here! :wave: 

The wheel specification requires that the `Tag` field contains all of the tags in their expanded form. Leaving the compressed form unchanged is usually "fine", but pip check (only!) misidentifies the wheel as incompatible with the system when fed a compressed wheel tag set. See also: https://github.com/pypa/pip/issues/13709

- https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/#compressed-tag-sets
- point 11 under "file contents" in https://packaging.python.org/en/latest/specifications/binary-distribution-format/#file-contents

While I'm unfamiliar with this repository and can't test the build script directly, the tag expansion logic has been tested below.

```pycon
>>> def expand(tag):
...     pytag, abitag, platformtag = tag.split("-")
...     return [
...         "-".join((x, y, z))
...         for z in platformtag.split(".")
...         for y in abitag.split(".")
...         for x in pytag.split(".")
...     ]
...     
>>> list(expand("py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64"))
['py3-none-manylinux_2_17_aarch64', 'py3-none-manylinux2014_aarch64', 'py3-none-musllinux_1_1_aarch64']
```

Unfortunately, other projects seem to be copying ziglang's wheel build scripts so this oversight has spread across the ecosystem.